### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Images
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ghvinerias/learning-golang/security/code-scanning/9](https://github.com/Ghvinerias/learning-golang/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow primarily reads repository contents and does not perform write operations.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
