### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-workflow.yml
+++ b/.github/workflows/dependabot-workflow.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -65,6 +67,8 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -88,6 +92,8 @@ jobs:
 
   build-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -141,6 +147,9 @@ jobs:
   dependabot-auto-approve:
     runs-on: ubuntu-latest
     needs: [test, build-check]
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ github.actor == 'dependabot[bot]' && success() }}
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
Potential fix for [https://github.com/Ghvinerias/learning-golang/security/code-scanning/8](https://github.com/Ghvinerias/learning-golang/security/code-scanning/8)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for each job. For example:
- The `test`, `security-scan`, and `build-check` jobs likely only need `contents: read` to access the repository's code.
- The `dependabot-auto-approve` job requires `contents: read` and `pull-requests: write` to add labels to pull requests.

The `permissions` block will be added at the job level for each job to ensure that permissions are tailored to the specific needs of each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
