### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/Zabbix-Client/zabbix.go
+++ b/Zabbix-Client/zabbix.go
@@ -13,8 +13,9 @@ func zabbixAPICall(request ZabbixRequest, response *ZabbixResponse) error {
 		return fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	// Print the full JSON request being sent
-	fmt.Println("Zabbix API Request:", string(reqBody))
+	// Print a sanitized version of the JSON request being sent
+	sanitizedReqBody := bytes.Replace(reqBody, []byte(apiKey), []byte("[REDACTED]"), -1)
+	fmt.Println("Zabbix API Request (sanitized):", string(sanitizedReqBody))
 
 	resp, err := http.Post(apiURL, "application/json", bytes.NewBuffer(reqBody))
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/Ghvinerias/learning-golang/security/code-scanning/10](https://github.com/Ghvinerias/learning-golang/security/code-scanning/10)

To fix the issue, the sensitive `apiKey` should be excluded or obfuscated before logging the request body. Instead of logging the full JSON request, we can log only non-sensitive fields or a placeholder message indicating that a request was sent. This ensures that sensitive information is not exposed in logs.

**Steps to implement the fix:**
1. Modify the logging statement on line 17 of `Zabbix-Client/zabbix.go` to exclude sensitive information.
2. Replace the logging of the full JSON request (`reqBody`) with a sanitized version that omits or obfuscates sensitive fields like `apiKey`.
3. Ensure that the fix does not alter the functionality of the API call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
