### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/bitwardern-sdk/main.go
+++ b/bitwardern-sdk/main.go
@@ -28,7 +28,7 @@ func main() {
 
     // Use the secret (e.g., API key)
     apiKey := secret.Data // Assuming Data contains the API key
-    fmt.Printf("API Key retrieved: %s\n", apiKey)
+    fmt.Println("API Key successfully retrieved.")
 
     // Use the API key to make a request to the OpenWeather API
     // e.g., makeRequestToOpenWeather(apiKey)


### PR DESCRIPTION
Potential fix for [https://github.com/Ghvinerias/learning-golang/security/code-scanning/11](https://github.com/Ghvinerias/learning-golang/security/code-scanning/11)

To fix the problem, we should avoid printing the API key in clear text to the console or logs. Instead, we can log a message indicating that the API key was successfully retrieved, without revealing its value. This change should be made in `bitwardern-sdk/main.go`, specifically on line 31. No additional imports or methods are required; simply modify the logging statement to omit the sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
